### PR TITLE
change baseUrl

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,5 +1,5 @@
 function configVariables() {
   return {
-    DUAL_PAY_API_BASE_URL: "http://localhost:3000",
+    DUAL_PAY_API_BASE_URL: "https://dual-pay-service.herokuapp.com",
   };
 }


### PR DESCRIPTION
Al estar el deploy de la API, ahora no tenemos que usar más localhost.

https://dual-pay-service.herokuapp.com/