### PR TITLE
improvements on the header/footer

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -20,7 +20,6 @@
     <div class="main-container">
         <div class="main">
             <header>
-                <div>
                     <div class="logo">Dual-Pay</div>
                     <nav>
                         <div class="header-icon">
@@ -29,7 +28,6 @@
                             <a href="#"><i class="fas fa-id-card-alt"></i> Contacto</a>
                         </div>
                     </nav>
-                </div>
             </header>
             <section class="section-container">
                 <div class="style-img">
@@ -55,9 +53,9 @@
                 </div>
                 <div class="box-style">
                     <h1>BANCO <span> <img class="img-responsive" src="imgs/bank.png"></span> </h1>
-                    <input class="style-radio" type="radio" name="currency" id="usdOption" disabled>
+                    <input id="style-radio" type="radio" name="currency" id="usdOption" disabled>
                     <label for="usd">USD</label>
-                    <input class="style-radio" type="radio" name="currency" id="pesosOption" disabled>
+                    <input id="style-radio" type="radio" name="currency" id="pesosOption" disabled>
                     <label for="pesos">Pesos</label>
                     <h3 class="usdOrPesos"></h3>
                     <input id="receivedMoneyInput" class="style-input" type="text" disabled>

--- a/src/public/style-header.css
+++ b/src/public/style-header.css
@@ -46,7 +46,7 @@ header nav a:hover {
 		margin-bottom:50px;
     }
     header .logo {
-        padding: 15px 0 0 0;
+        padding: 15px 0 0 16px;
     }
     header nav {
         padding: 0;

--- a/src/public/style-header.css
+++ b/src/public/style-header.css
@@ -1,34 +1,32 @@
 .header-icon {
 	display: flex;
 	letter-spacing: 1.2px;
-	float: left;
 }
 header {
+	display: flex;
+    align-items: center;
+	justify-content: space-between;
 	width:100%;
+	height: 150px;
 	overflow:hidden;
 	background:rgb(122, 151, 180);
-	margin-bottom:20px;
-	flex-direction: column;
-    align-items: flex-start;
 }
 header .logo {
 	color:#f2f2f2;
 	font-size:50px;
-	line-height:200px;
-	float:left;
-    font-family:"Avantgarde", Century "Gothic", "CenturyGothic", "AppleGothic", sans-serif;;
+	padding: 42px;
 	letter-spacing: 1.2px;
 }
 header nav {
-	line-height:200px;
 	float: right;
-	line-height: 200px;
+	padding: 42px;
 }
 header nav a {
 	display:inline-block;
 	color:#fff;
 	text-decoration:none;
-	padding:10px 20px;
+	text-align: center;
+	padding:10px 16px;
 	line-height:normal;
 	font-size:20px;
 	font-weight:bold;
@@ -41,4 +39,16 @@ header nav a {
 header nav a:hover {
 	background:rgb(89, 93, 97);
 	border-radius:50px;
+}
+@media (max-width: 460px) {
+    header {
+        display: inline-block;
+		margin-bottom:50px;
+    }
+    header .logo {
+        padding: 15px 0 0 0;
+    }
+    header nav {
+        padding: 0;
+    } 
 }

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -10,7 +10,7 @@ body {
 }
 .main {
     overflow: auto;
-    padding-bottom: 100px;
+    padding-bottom: 150px;
 }
 .section-container {
     display: flex;
@@ -47,9 +47,9 @@ h3 {
 .style-input {
     margin-top: 20px;
 }
-.style-radio {
-    width: 15px !important;
-    height: 13px !important;
+#style-radio {
+    width: 15px;
+    height: 13px;
 }
 .usdOrPesos {
     margin: 0px;
@@ -82,21 +82,19 @@ h3 {
     display: flex;
     justify-content: center;
     align-items: center;
+    color: #f2f2f2;
+    letter-spacing: 1.2px
 }
 .github {
     text-decoration: none;
-    color: black;
+    color: #f2f2f2;
     font-weight: 600;
     font-size: 13px;
+    letter-spacing: 1.2px
 }
  /*Responsive*/
  @media (max-width: 460px) {
 
-    .header-icon {
-        display: block;
-        justify-content: center;
-        float:left;
-    }
     .section-container {
          display: flex;
          flex-direction: column;


### PR DESCRIPTION
This branch was created to change the footer styles to match those of the header. Also the header was modified with flexbox so that its elements are on the same line, and spaced between them, it was also given a padding so that they are separated from the margin of the screen. 
This is how you'll see it in 1920 x 1080:
![image](https://user-images.githubusercontent.com/86069162/147576865-b10f1d9b-902b-489d-a24d-7c166251ccc8.png)
There were also changes for mobile uses. The navigation icons are in the center, and both the title and the nav are separated with padding from the left margin of the screen.
![image](https://user-images.githubusercontent.com/86069162/147577502-cbe08347-78af-428b-87a4-b3340a7abb60.png)
And for last but not less important, there where an improvement on the style.css, we where using **!important** to style the radio button, because of that it was changed the class for an ID. 