### PR TITLE
Bugfix/radio options broken

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -51,7 +51,7 @@
                     <h3>Nominals</h3>
                     <input id="nominalsInput" type="text" disabled>
                 </div>
-                <div class="box-style">
+                <div id="radio-container" class="box-style">
                     <h1>BANCO <span> <img class="img-responsive" src="imgs/bank.png"></span> </h1>
                     <input class="radio" type="radio" name="currency" id="usdOption" disabled>
                     <label for="usd">USD</label>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -53,9 +53,9 @@
                 </div>
                 <div class="box-style">
                     <h1>BANCO <span> <img class="img-responsive" src="imgs/bank.png"></span> </h1>
-                    <input id="style-radio" type="radio" name="currency" id="usdOption" disabled>
+                    <input class="radio" type="radio" name="currency" id="usdOption" disabled>
                     <label for="usd">USD</label>
-                    <input id="style-radio" type="radio" name="currency" id="pesosOption" disabled>
+                    <input class="radio" type="radio" name="currency" id="pesosOption" disabled>
                     <label for="pesos">Pesos</label>
                     <h3 class="usdOrPesos"></h3>
                     <input id="receivedMoneyInput" class="style-input" type="text" disabled>

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -47,7 +47,8 @@ h3 {
 .style-input {
     margin-top: 20px;
 }
-#style-radio {
+
+div#radio-container .radio {
     width: 15px;
     height: 13px;
 }


### PR DESCRIPTION
**Error:** Uncaught (in promise) TypeError: Cannot set properties of null (setting 'checked')

El problema era que las opciones de los radio buttons tenían ID doble (se nos pasó en algún PR anterior).

- Se arregla dicho error
- Se agrega un ID al contenedor de las opciones
- Se aplica especificidad en el estilo correspondiente a las option. [Documentación](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity).

**Captura demostrando que toma los estilos:**

![image](https://user-images.githubusercontent.com/39744836/147676198-9563f3a5-a40d-4f8d-a48f-43c6bd4a0b05.png)
